### PR TITLE
added seeding for courses, lessons, and an admin user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise_token_auth', "~> 1.0.0"
 
 group :development, :test do
+  gem 'faker', :git => 'https://github.com/stympy/faker.git', :branch => 'master'
+  gem 'database_cleaner'
   gem 'pry'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/stympy/faker.git
+  revision: f03d4eec1b11b8a03413c89b7d2cadcd0cfd6ef9
+  branch: master
+  specs:
+    faker (1.9.4)
+      i18n (>= 0.7)
+      pastel (~> 0.7.2)
+      thor (~> 0.20.0)
+      tty-pager (~> 0.12.0)
+      tty-screen (~> 0.6.5)
+      tty-tree (~> 0.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -50,6 +63,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -59,6 +73,7 @@ GEM
     devise_token_auth (1.0.0)
       devise (> 3.5.2, < 4.6)
       rails (>= 4.2.0, < 6)
+    equatable (0.6.1)
     erubi (1.8.0)
     ffi (1.11.1)
     globalid (0.4.2)
@@ -86,6 +101,9 @@ GEM
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pastel (0.7.3)
+      equatable (~> 0.6)
+      tty-color (~> 0.5)
     pg (1.1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -137,10 +155,25 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strings (0.1.5)
+      strings-ansi (~> 0.1)
+      unicode-display_width (~> 1.5)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    tty-color (0.5.0)
+    tty-pager (0.12.1)
+      strings (~> 0.1.4)
+      tty-screen (~> 0.6)
+      tty-which (~> 0.4)
+    tty-screen (0.6.5)
+    tty-tree (0.3.0)
+    tty-which (0.4.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
+    unicode_utils (1.4.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     websocket-driver (0.7.1)
@@ -152,7 +185,9 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  database_cleaner
   devise_token_auth (~> 1.0.0)
+  faker!
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::API
 
   protected
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:admin])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :admin])
     end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,38 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+require 'database_cleaner'
 
+DatabaseCleaner.clean_with(:truncation)
+
+user = User.new({
+  name: 'admin',
+  email: 'admin@email.com',
+  password: 'password',
+  admin: true
+})
+user.save!
+
+courses = [1,2,3,4,5,6,7,8,9,10]
+
+10.times do
+  course = Course.create(
+    title: Faker::Book.title,
+    subtitle: Faker::Book.genre,
+    description: Faker::Quote.famous_last_words
+  )
+ 
+100.times do 
+  lesson = Lesson.create(
+      instructor: Faker::GreekPhilosophers.name,
+      title: Faker::Hipster.word,
+      subtitle: Faker::Hipster.sentence,
+      description:Faker::Hipster.paragraph,
+      length: Faker::Number.between(4, 20),
+      complete: false,
+      course_id: courses.sample
+  )
+  
+
+  end
+end
+
+puts "Data Seeded."


### PR DESCRIPTION
I updated seed.rb with logic to create 10 courses, 100 lessons (distributed randomly to the courses), and an admin user.

I added two gem files so you will need to run 'bundle install' and 'gem install faker' after pulling down master.

To seed the database with the courses, lessons, and user run 'bundle exec rake db:seed'
There will be a success message that says 'Data Seeded'.

Also, I installed the database cleaner gem so each time you run 'rake db:seed' the database will be wiped and then seeded. This will make sure there isn't any duplicates also as we run through crud actions we can simply run rake db:seed to clean up the db.